### PR TITLE
Made some corrections based on previous presentation

### DIFF
--- a/api/db/query/message.sql
+++ b/api/db/query/message.sql
@@ -14,8 +14,15 @@ VALUES ($1, $2, $3, $4);
 SELECT * FROM verification WHERE user_uuid = $1 LIMIT 1;
 
 -- name: GetUsersPendingVerification :many
-SELECT Uuid, CONCAT(fname, ' ', lname) AS name, account_status AS status, email,role FROM "user"
-WHERE account_status = 'pending';
+SELECT 
+  u.uuid,
+  CONCAT(u.fname, ' ', u.lname) AS name,
+  u.account_status AS status,
+  u.email,
+  u.role
+FROM "user" u
+INNER JOIN verification v ON v.user_uuid = u.uuid
+WHERE u.account_status = 'pending';
 
 -- name: GetUserVerificationDetails :one
 SELECT 

--- a/api/db/query/message.sql
+++ b/api/db/query/message.sql
@@ -3,6 +3,9 @@ INSERT INTO "user" (fname,lname,email,gender,phone,zip_code,city,street,region,r
 VALUES ($1, $2, $3,$4,$5,$6,$7,$8,$9,$10)
 RETURNING email;
 
+-- name: GetUserByUuid :one
+SELECT * FROM "user" WHERE uuid = $1;
+
 -- name: GetUserByEmail :one
 SELECT Uuid,email,lname,role,account_status FROM "user" WHERE email = $1;
 

--- a/api/db/repo/message.sql.go
+++ b/api/db/repo/message.sql.go
@@ -71,6 +71,32 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (GetUserByEm
 	return i, err
 }
 
+const getUserByUuid = `-- name: GetUserByUuid :one
+SELECT uuid, fname, lname, email, gender, phone, zip_code, city, street, region, photo_url, role, account_status, created_at FROM "user" WHERE uuid = $1
+`
+
+func (q *Queries) GetUserByUuid(ctx context.Context, uuid string) (User, error) {
+	row := q.db.QueryRow(ctx, getUserByUuid, uuid)
+	var i User
+	err := row.Scan(
+		&i.Uuid,
+		&i.Fname,
+		&i.Lname,
+		&i.Email,
+		&i.Gender,
+		&i.Phone,
+		&i.ZipCode,
+		&i.City,
+		&i.Street,
+		&i.Region,
+		&i.PhotoUrl,
+		&i.Role,
+		&i.AccountStatus,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getUserVerificationDetails = `-- name: GetUserVerificationDetails :one
 SELECT 
     u.uuid AS user_uuid,

--- a/api/db/repo/message.sql.go
+++ b/api/db/repo/message.sql.go
@@ -108,8 +108,15 @@ func (q *Queries) GetUserVerificationDetails(ctx context.Context, uuid string) (
 }
 
 const getUsersPendingVerification = `-- name: GetUsersPendingVerification :many
-SELECT Uuid, CONCAT(fname, ' ', lname) AS name, account_status AS status, email,role FROM "user"
-WHERE account_status = 'pending'
+SELECT 
+  u.uuid,
+  CONCAT(u.fname, ' ', u.lname) AS name,
+  u.account_status AS status,
+  u.email,
+  u.role
+FROM "user" u
+INNER JOIN verification v ON v.user_uuid = u.uuid
+WHERE u.account_status = 'pending'
 `
 
 type GetUsersPendingVerificationRow struct {

--- a/api/db/repo/querier.go
+++ b/api/db/repo/querier.go
@@ -11,6 +11,7 @@ import (
 type Querier interface {
 	CreateUser(ctx context.Context, arg CreateUserParams) (string, error)
 	GetUserByEmail(ctx context.Context, email string) (GetUserByEmailRow, error)
+	GetUserByUuid(ctx context.Context, uuid string) (User, error)
 	GetUserVerificationDetails(ctx context.Context, uuid string) (GetUserVerificationDetailsRow, error)
 	GetUsersPendingVerification(ctx context.Context) ([]GetUsersPendingVerificationRow, error)
 	GetVerificationByUserUuid(ctx context.Context, userUuid string) (Verification, error)


### PR DESCRIPTION
Fetch only pending users who have submitted verification status
Also prevents double user account status update, ie a user account status cannot change from rejected to approved or vice versa, it can only be changed from pending to either approved or rejected