### PR TITLE
Add new AWS Secret for Cloudinary Environment Variable

### DIFF
--- a/infra/cloudformation/services/api.yaml
+++ b/infra/cloudformation/services/api.yaml
@@ -61,6 +61,19 @@ Parameters:
 
 Resources:
 
+  CloudinarySecret:
+    Type: "AWS::SecretsManager::Secret"
+    Properties:
+      Name: !Sub "/${EnvId}/Cloudinary"
+      GenerateSecretString:
+        SecretStringTemplate: !Sub '{}'
+        GenerateStringKey: "name"
+        PasswordLength: 30
+        ExcludePunctuation: true
+      Tags:
+        - Key: EnvId
+          Value: !Ref EnvId
+
   AppDatabaseSecret:
     Type: "AWS::SecretsManager::Secret"
     Properties:
@@ -133,6 +146,8 @@ Resources:
               ValueFrom: !Sub "${DbAdminSecretArn}:port::"
             - Name: DB_PASSWORD
               ValueFrom: !Sub "${AppDatabaseSecret}:password::"
+            - Name: CLOUDINARY_CLOUD_NAME
+              ValueFrom: !Sub "${CloudinarySecret}:name::"
 
     # A role needed by ECS to Start the Ecs Service
   ExecutionRole:


### PR DESCRIPTION
This adds a new environment variable to the API for the Cloudinary cloud name. This environment variable was missing rfomr the task definition which was preventing the API service from starting 