### PR TITLE
Grant the API access to the Cloudinary Secret

### DIFF
--- a/infra/cloudformation/services/api.yaml
+++ b/infra/cloudformation/services/api.yaml
@@ -177,6 +177,7 @@ Resources:
                 Resource:
                   - !Ref AppDatabaseSecret
                   - !Ref DbAdminSecretArn
+                  - !Ref CloudinarySecret
 
   # A role for the containers
   TaskRole:


### PR DESCRIPTION
Thsi was missed in the previous PR. This just grants the API execution role read permission to the Cloudinary secret.